### PR TITLE
remove duplicate spdep listing

### DIFF
--- a/RSPARROW_master/DESCRIPTION
+++ b/RSPARROW_master/DESCRIPTION
@@ -13,8 +13,7 @@ Depends:
     methods
 Imports:
     numDeriv,
-    nlmrt,
-    spdep,
+    nlmrt,    
     stringr,
     gear,
     gplots,


### PR DESCRIPTION
the `spdep` package was listed twice and flagged by `devtools::check`