### PR TITLE
Specify OS_type as the package is Windows only

### DIFF
--- a/RSPARROW_master/DESCRIPTION
+++ b/RSPARROW_master/DESCRIPTION
@@ -7,6 +7,7 @@ Author: Richard Alexander, Lillian Gorman Sanisaca
 Maintainer: Richard Alexander <ralex@usgs.gov>, Lillian Gorman Sanisaca <lgormansanisaca@usgs.gov>
 Description: Setup and execution of the USGS SPARROW water-quality model for a user-defined domain.
 Roxygen: list(markdown=TRUE)
+OS_type: windows
 VignetteBuilder: knitr
 Depends:
     R(>= 4.0.3),


### PR DESCRIPTION
Per section 1.1.1 of CRAN's [Writing R Extensions](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file):

> The ‘OS_type’ field specifies the OS(es) for which the package is intended. If present, it should be one of unix or windows, and indicates that the package can only be installed on a platform with ‘.Platform$OS.type’ having that value. 